### PR TITLE
refactor(goner): rename interfaces to g and update related packages

### DIFF
--- a/cmux/go.mod
+++ b/cmux/go.mod
@@ -4,11 +4,14 @@ go 1.24.1
 
 require (
 	github.com/gone-io/gone/v2 v2.0.7
+	github.com/gone-io/goner/g v0.0.0-00010101000000-000000000000
 	github.com/gone-io/goner/tracer v0.0.1
 	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.0
 )
+
+replace github.com/gone-io/goner/g => ../g
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/examples/gin_gorm_viper/go.mod
+++ b/examples/gin_gorm_viper/go.mod
@@ -3,7 +3,7 @@ module gin_gorm_viper
 go 1.24.1
 
 require (
-	github.com/gone-io/gone/v2 v2.0.6
+	github.com/gone-io/gone/v2 v2.0.7
 	github.com/gone-io/goner v0.0.3
 	github.com/gone-io/goner/gin v0.0.0-20250321103707-52f1be0edf49
 	github.com/gone-io/goner/gorm v0.0.0-00010101000000-000000000000

--- a/examples/gin_gorm_viper/go.sum
+++ b/examples/gin_gorm_viper/go.sum
@@ -41,6 +41,7 @@ github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gone-io/gone/v2 v2.0.6 h1:OsshPSwqftNU39h5EC3o/svMVUeKkjDBKUVmndNdH5g=
 github.com/gone-io/gone/v2 v2.0.6/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
+github.com/gone-io/gone/v2 v2.0.7/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
 github.com/gone-io/goner/cmux v0.0.0-20250321103707-52f1be0edf49 h1:hJH6n0ZGzDCZjQHoJEjJtNJoA6piZulK3Bl+K/CFUQ0=
 github.com/gone-io/goner/cmux v0.0.0-20250321103707-52f1be0edf49/go.mod h1:B4wFP1powK0GLR86i3csCigc7vwyc/2+3frWhrJR+A8=
 github.com/gone-io/goner/tracer v0.0.1 h1:/IKaL53r5YvVH53wG18mxkebrkolFiW+riSoXf2IZBQ=

--- a/g/cmux.go
+++ b/g/cmux.go
@@ -1,0 +1,17 @@
+package g
+
+import (
+	"net"
+)
+
+type ProtocolType int
+
+const (
+	GRPC  ProtocolType = 0x01
+	HTTP1 ProtocolType = 0x01 << 1
+)
+
+type Cmux interface {
+	MatchFor(ProtocolType) net.Listener
+	GetAddress() string
+}

--- a/g/go.mod
+++ b/g/go.mod
@@ -1,0 +1,3 @@
+module github.com/gone-io/goner/g
+
+go 1.24.1

--- a/g/locker.go
+++ b/g/locker.go
@@ -1,0 +1,7 @@
+package g
+
+import "time"
+
+type DoLocker interface {
+	LockAndDo(key string, fn func(), lockTime, checkPeriod time.Duration) (err error)
+}

--- a/g/registry.go
+++ b/g/registry.go
@@ -1,4 +1,4 @@
-package svc
+package g
 
 // Endpoint interface for service.
 type Endpoint interface {

--- a/g/router.go
+++ b/g/router.go
@@ -1,4 +1,4 @@
-package svc
+package g
 
 type ServiceRouter interface {
 	GetServiceAddress(serviceName string) (serviceAddress string, err error)

--- a/g/tracer.go
+++ b/g/tracer.go
@@ -1,0 +1,15 @@
+package g
+
+// Tracer Log tracking, which is used to assign a unified traceId to the same call link to facilitate log tracking.
+type Tracer interface {
+
+	//SetTraceId to set `traceId` to the calling function. If traceId is an empty string, an automatic one will
+	//be generated. TraceId can be obtained by using the GetTraceId () method in the calling function.
+	SetTraceId(traceId string, fn func())
+
+	//GetTraceId Get the traceId of the current goroutine
+	GetTraceId() string
+
+	//Go Start a new goroutine instead of `go func`, which can pass the traceId to the new goroutine.
+	Go(fn func())
+}

--- a/grpc/example/go.mod
+++ b/grpc/example/go.mod
@@ -3,7 +3,7 @@ module grpc_demo
 go 1.24.1
 
 require (
-	github.com/gone-io/gone/v2 v2.0.6
+	github.com/gone-io/gone/v2 v2.0.7
 	github.com/gone-io/goner/grpc v0.0.0-00010101000000-000000000000
 	github.com/gone-io/goner/viper v0.0.1
 	google.golang.org/grpc v1.71.0

--- a/grpc/example/go.sum
+++ b/grpc/example/go.sum
@@ -20,6 +20,7 @@ github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gone-io/gone/v2 v2.0.6 h1:OsshPSwqftNU39h5EC3o/svMVUeKkjDBKUVmndNdH5g=
 github.com/gone-io/gone/v2 v2.0.6/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
+github.com/gone-io/gone/v2 v2.0.7/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
 github.com/gone-io/goner/tracer v0.0.1 h1:/IKaL53r5YvVH53wG18mxkebrkolFiW+riSoXf2IZBQ=
 github.com/gone-io/goner/tracer v0.0.1/go.mod h1:UL4lRTaqyf0ctOsmNZj263DqXT1YIsSL0IWyhxb02oo=
 github.com/gone-io/goner/viper v0.0.1 h1:m3MbyjyyKINF/LAwxWvTWRT3mtMLpS6BY266kWWZnFQ=

--- a/interfaces/go.mod
+++ b/interfaces/go.mod
@@ -1,3 +1,0 @@
-module github.com/gone-io/goner/interfaces
-
-go 1.24.1

--- a/nacos/go.mod
+++ b/nacos/go.mod
@@ -2,13 +2,13 @@ module github.com/gone-io/goner/nacos
 
 go 1.24.1
 
-replace github.com/gone-io/goner/interfaces => ../interfaces
+replace github.com/gone-io/goner/g => ../g
 
 require (
 	github.com/bytedance/sonic v1.13.2
 	github.com/goccy/go-json v0.10.5
-	github.com/gone-io/gone/v2 v2.0.6
-	github.com/gone-io/goner/interfaces v0.0.0-00010101000000-000000000000
+	github.com/gone-io/gone/v2 v2.0.7
+	github.com/gone-io/goner/g v0.0.0-00010101000000-000000000000
 	github.com/gone-io/goner/viper v0.0.1
 	github.com/json-iterator/go v1.1.12
 	github.com/nacos-group/nacos-sdk-go/v2 v2.2.9

--- a/nacos/go.sum
+++ b/nacos/go.sum
@@ -122,6 +122,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/gone-io/gone/v2 v2.0.6 h1:OsshPSwqftNU39h5EC3o/svMVUeKkjDBKUVmndNdH5g=
 github.com/gone-io/gone/v2 v2.0.6/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
+github.com/gone-io/gone/v2 v2.0.7 h1:cIm8JeNUO+EV6G+M18e4N/i1Kc0DERVs2ssL/+sM1m0=
+github.com/gone-io/gone/v2 v2.0.7/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
 github.com/gone-io/goner/viper v0.0.1 h1:m3MbyjyyKINF/LAwxWvTWRT3mtMLpS6BY266kWWZnFQ=
 github.com/gone-io/goner/viper v0.0.1/go.mod h1:tgnEw7K2iJ1uW9ikztLWYyEjM0J6LtqJLrjftxJPh4A=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/nacos/name_client.go
+++ b/nacos/name_client.go
@@ -3,7 +3,7 @@ package nacos
 import (
 	"fmt"
 	"github.com/gone-io/gone/v2"
-	"github.com/gone-io/goner/interfaces/svc"
+	svc "github.com/gone-io/goner/g"
 	"github.com/gone-io/goner/nacos/internal/json"
 	"github.com/nacos-group/nacos-sdk-go/v2/clients"
 	"github.com/nacos-group/nacos-sdk-go/v2/clients/naming_client"

--- a/schedule/example/go.mod
+++ b/schedule/example/go.mod
@@ -3,7 +3,7 @@ module example
 go 1.24.1
 
 require (
-	github.com/gone-io/gone/v2 v2.0.6
+	github.com/gone-io/gone/v2 v2.0.7
 	github.com/gone-io/goner/redis v0.0.0-00010101000000-000000000000
 	github.com/gone-io/goner/schedule v0.0.0-00010101000000-000000000000
 	github.com/gone-io/goner/viper v0.0.1

--- a/schedule/example/go.sum
+++ b/schedule/example/go.sum
@@ -24,6 +24,7 @@ github.com/gomodule/redigo v1.9.2 h1:HrutZBLhSIU8abiSfW8pj8mPhOyMYjZT/wcA4/L9L9s
 github.com/gomodule/redigo v1.9.2/go.mod h1:KsU3hiK/Ay8U42qpaJk+kuNa3C+spxapWpM+ywhcgtw=
 github.com/gone-io/gone/v2 v2.0.6 h1:OsshPSwqftNU39h5EC3o/svMVUeKkjDBKUVmndNdH5g=
 github.com/gone-io/gone/v2 v2.0.6/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
+github.com/gone-io/gone/v2 v2.0.7/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
 github.com/gone-io/goner/tracer v0.0.1 h1:/IKaL53r5YvVH53wG18mxkebrkolFiW+riSoXf2IZBQ=
 github.com/gone-io/goner/tracer v0.0.1/go.mod h1:UL4lRTaqyf0ctOsmNZj263DqXT1YIsSL0IWyhxb02oo=
 github.com/gone-io/goner/viper v0.0.1 h1:m3MbyjyyKINF/LAwxWvTWRT3mtMLpS6BY266kWWZnFQ=

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -16,11 +16,6 @@ func Load(loader gone.Loader) error {
 	return load(loader)
 }
 
-// Priest Deprecated, use Load instead
-func Priest(loader gone.Loader) error {
-	return Load(loader)
-}
-
 type schedule struct {
 	gone.Flag
 


### PR DESCRIPTION
- Rename interfaces package to g
- Update cmux package to use new g package- Update nacos, schedule, and other packages to use new g package- Remove deprecated Priest function from cmux and schedule packages
- Add MatchFor function to cmux package
- Update go.mod and go.sum files across multiple packages