### PR TITLE
refactor(cmux): Remove the dependency on the github.com/gone-io/goner…

### DIFF
--- a/cmux/cmux.go
+++ b/cmux/cmux.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/gone-io/gone/v2"
 	"github.com/gone-io/goner/g"
-	"github.com/gone-io/goner/tracer"
 	"github.com/soheilhy/cmux"
 	"net"
 	"net/http"
@@ -15,10 +14,6 @@ import (
 const Name = "cmux"
 
 var load = gone.OnceLoad(func(loader gone.Loader) error {
-	err := tracer.Load(loader)
-	if err != nil {
-		return gone.ToError(err)
-	}
 	return loader.Load(
 		&server{listen: net.Listen},
 		gone.IsDefault(new(CMuxServer)),
@@ -34,8 +29,8 @@ type server struct {
 	gone.Flag
 	once   sync.Once
 	cMux   cmux.CMux
-	logger gone.Logger   `gone:"*"`
-	tracer tracer.Tracer `gone:"*" option:"allowNil"`
+	logger gone.Logger `gone:"*"`
+	tracer g.Tracer    `gone:"*" option:"allowNil"`
 
 	stopFlag bool
 	lock     sync.Mutex

--- a/cmux/go.mod
+++ b/cmux/go.mod
@@ -5,7 +5,6 @@ go 1.24.1
 require (
 	github.com/gone-io/gone/v2 v2.0.7
 	github.com/gone-io/goner/g v0.0.0-00010101000000-000000000000
-	github.com/gone-io/goner/tracer v0.0.1
 	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.0
@@ -15,10 +14,6 @@ replace github.com/gone-io/goner/g => ../g
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/gopherjs/gopherjs v1.17.2 // indirect
-	github.com/jtolds/gls v4.20.0+incompatible // indirect
-	github.com/petermattis/goid v0.0.0-20250319124200-ccd6737f222a // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb // indirect
 	golang.org/x/text v0.3.3 // indirect

--- a/cmux/go.sum
+++ b/cmux/go.sum
@@ -2,16 +2,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gone-io/gone/v2 v2.0.7 h1:cIm8JeNUO+EV6G+M18e4N/i1Kc0DERVs2ssL/+sM1m0=
 github.com/gone-io/gone/v2 v2.0.7/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
-github.com/gone-io/goner/tracer v0.0.1 h1:/IKaL53r5YvVH53wG18mxkebrkolFiW+riSoXf2IZBQ=
-github.com/gone-io/goner/tracer v0.0.1/go.mod h1:UL4lRTaqyf0ctOsmNZj263DqXT1YIsSL0IWyhxb02oo=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
-github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
-github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
-github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/petermattis/goid v0.0.0-20250319124200-ccd6737f222a h1:S+AGcmAESQ0pXCUNnRH7V+bOUIgkSX5qVt2cNKCrm0Q=
-github.com/petermattis/goid v0.0.0-20250319124200-ccd6737f222a/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=


### PR DESCRIPTION
…/tracer package to reduce the number of dependent projects in the project.

- Remove tracer package from cmux.go
- Update go.mod and go.sum to reflect the removal of the tracer package