### PR TITLE
test(apollo): add unit tests for ApolloConfigure Init method

### DIFF
--- a/apollo/configure.go
+++ b/apollo/configure.go
@@ -13,7 +13,6 @@ type apolloConfigure struct {
 	gone.Flag
 	client   agollo.Client
 	testFlag gone.TestFlag `gone:"*" option:"allowNil"`
-	logger   gone.Logger   `gone:"*" option:"lazy"`
 
 	*viper.RemoteConfigure
 
@@ -63,9 +62,11 @@ func (s *apolloConfigure) init(localConfigure gone.Configure) (*config.AppConfig
 }
 
 var startWithConfig = agollo.StartWithConfig
+var viperNew = viper.New
+var originViperNew = originViper.New
 
 func (s *apolloConfigure) Init() error {
-	configure := viper.New(s.testFlag)
+	configure := viperNew(s.testFlag)
 	appConfig, err := s.init(configure)
 	if err != nil {
 		return gone.ToError(err)
@@ -81,12 +82,12 @@ func (s *apolloConfigure) Init() error {
 
 	namespaces := strings.Split(s.namespace, ",")
 
-	total := originViper.New()
+	total := originViperNew()
 	for _, ns := range namespaces {
 		cache := s.client.GetConfigCache(ns)
 		if cache != nil {
 			if s.watch {
-				v := originViper.New()
+				v := originViperNew()
 				cache.Range(func(key, value interface{}) bool {
 					if k, ok := key.(string); ok {
 						v.Set(k, value)

--- a/apollo/configure_init_test.go
+++ b/apollo/configure_init_test.go
@@ -1,0 +1,119 @@
+package apollo
+
+import (
+	"testing"
+
+	"github.com/apolloconfig/agollo/v4"
+	"github.com/apolloconfig/agollo/v4/env/config"
+	"github.com/gone-io/gone/v2"
+	originViper "github.com/spf13/viper"
+	"go.uber.org/mock/gomock"
+)
+
+func TestApolloConfigureInitMethod(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Mock dependencies
+	mockClient := NewMockClient(ctrl)
+	mockCache := NewMockCacheInterface(ctrl)
+	mockLocalConfigure := NewMockConfigure(ctrl)
+	mockViper := originViper.New()
+
+	// Mock behavior
+	oldStartWithConfig := startWithConfig
+	oldViperNew := viperNew
+	oldOriginViperNew := originViperNew
+	defer func() {
+		startWithConfig = oldStartWithConfig
+		viperNew = oldViperNew
+		originViperNew = oldOriginViperNew
+	}()
+
+	startWithConfig = func(configFunc func() (*config.AppConfig, error)) (agollo.Client, error) {
+		return mockClient, nil
+	}
+	viperNew = func(testFlag gone.TestFlag) gone.Configure {
+		return mockLocalConfigure
+	}
+	originViperNew = func() *originViper.Viper {
+		return mockViper
+	}
+
+	watch := false
+
+	mockLocalConfigure.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		Do(func(key string, value any, defaultVal string) {
+			if key == "apollo.watch" {
+				*value.(*bool) = watch
+			}
+		}).
+		AnyTimes()
+
+	// Test cases
+	t.Run("success case with watch enabled", func(t *testing.T) {
+		watch = true
+
+		listener := changeListener{}
+		listener.Init()
+
+		configure := &apolloConfigure{
+			testFlag:       nil,
+			changeListener: &listener,
+		}
+
+		mockClient.EXPECT().GetConfigCache(gomock.Any()).Return(mockCache).AnyTimes()
+		mockCache.EXPECT().Range(gomock.Any()).DoAndReturn(func(f func(key, value interface{}) bool) {
+			f("key1", "value1")
+			f("key2", "value2")
+		}).AnyTimes()
+		mockClient.EXPECT().AddChangeListener(gomock.Any()).Times(1)
+
+		err := configure.Init()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("success case without watch", func(t *testing.T) {
+		watch = false
+
+		configure := &apolloConfigure{
+			testFlag:       nil,
+			changeListener: &changeListener{},
+			watch:          false,
+		}
+
+		mockClient.EXPECT().GetConfigCache(gomock.Any()).Return(mockCache).AnyTimes()
+		mockCache.EXPECT().Range(gomock.Any()).DoAndReturn(func(f func(key, value interface{}) bool) {
+			f("key1", "value1")
+			f("key2", "value2")
+		}).AnyTimes()
+
+		err := configure.Init()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("error case - client initialization fails", func(t *testing.T) {
+		mockLocalConfigure.EXPECT().
+			Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			AnyTimes()
+
+		startWithConfig = func(configFunc func() (*config.AppConfig, error)) (agollo.Client, error) {
+			return nil, gone.ToError("client init error")
+		}
+
+		configure := &apolloConfigure{
+			testFlag:       nil,
+			changeListener: &changeListener{},
+		}
+
+		err := configure.Init()
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+}

--- a/apollo/go.mod
+++ b/apollo/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/apollo/go.sum
+++ b/apollo/go.sum
@@ -265,6 +265,8 @@ github.com/spf13/viper v1.20.0/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqj
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/examples/config_center/etcd/go.mod
+++ b/examples/config_center/etcd/go.mod
@@ -3,8 +3,8 @@ module examples/config_center/etcd
 go 1.24.1
 
 require (
-	github.com/gone-io/gone/v2 v2.0.7
-	github.com/gone-io/goner/viper/remote v1.0.2
+	github.com/gone-io/gone/v2 v2.0.9
+	github.com/gone-io/goner/viper/remote v1.0.4
 )
 
 replace github.com/gone-io/goner/viper/remote => ../../../viper/remote
@@ -28,7 +28,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/gone-io/goner/viper v1.0.2 // indirect
+	github.com/gone-io/goner/viper v1.0.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect

--- a/examples/config_center/etcd/go.sum
+++ b/examples/config_center/etcd/go.sum
@@ -74,10 +74,10 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/gone-io/gone/v2 v2.0.7 h1:cIm8JeNUO+EV6G+M18e4N/i1Kc0DERVs2ssL/+sM1m0=
-github.com/gone-io/gone/v2 v2.0.7/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
-github.com/gone-io/goner/viper v1.0.2 h1:3ENSQDZNvp8YWVMh/Kz3orVvHj/IOSJm1vBjQSZW0Ac=
-github.com/gone-io/goner/viper v1.0.2/go.mod h1:OG2cqATkJsXivNehGD81XjgUip6X2MJbMmmuSjdFujQ=
+github.com/gone-io/gone/v2 v2.0.9 h1:/dTjRPwoOdaq6TYSRmEju7N1UunfWrpSHn5fwenv4Go=
+github.com/gone-io/gone/v2 v2.0.9/go.mod h1:R6eUqkbiF/L6Lfd7OsUzNW1SpaXhUb7zc8nQj/i04xE=
+github.com/gone-io/goner/viper v1.0.4 h1:m5ZFBZuBIfSWG9rdLeHbpSg7X3nmnMPUervsfOVrfw4=
+github.com/gone-io/goner/viper v1.0.4/go.mod h1:aSe1uuvtvHKe2gWpv9iHrTnuJJtYhqcR1mBPyfD+Ebk=
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -282,6 +282,8 @@ go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
+go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=


### PR DESCRIPTION
- Implement unit tests for ApolloConfigure Init method using mock dependencies
- Cover different scenarios including watch enabled, watch disabled, and client initialization failure
- Update go.mod and go.sum files with new dependencies
- Remove unused logger field from ApolloConfigure struct