### PR TITLE
ci(dependabot): set up weekly dependency updates for Go modules and G…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # Go modules
+    directory: "/" # Location of go.mod
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions" # GitHub Actions
+    directory: "/" # Location of workflow files (.github/workflows)
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+


### PR DESCRIPTION
…itHub Actions

- Add Dependabot configuration for Go modules and GitHub Actions
- Set up weekly updates for both ecosystems- Limit open pull requests to 10 for each
- Add appropriate labels for dependencies and ecosystems
- Configure commit message prefixes and content