### PR TITLE
feat(openai): add support for HTTP proxies

### DIFF
--- a/g/http.go
+++ b/g/http.go
@@ -1,0 +1,7 @@
+package g
+
+import "net/http"
+
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}

--- a/openai/README.md
+++ b/openai/README.md
@@ -30,6 +30,30 @@ openai:
   proxyUrl: ""                   # Optional: HTTP proxy URL
 ```
 
+### Proxy Configuration (proxyUrl)
+
+The `proxyUrl` parameter is used to access the OpenAI API through an HTTP proxy in network-restricted environments. This is particularly useful in the following scenarios:
+
+- When your network environment cannot directly access the OpenAI API
+- When you need to access external APIs through corporate proxies or VPNs
+- To improve API access speed and stability
+
+Configuration example:
+
+```yaml
+openai:
+  apiToken: "your-api-key"
+  proxyUrl: "http://proxy.example.com:8080"  # HTTP proxy server address and port
+```
+
+You can also use a proxy with authentication:
+
+```yaml
+openai:
+  apiToken: "your-api-key"
+  proxyUrl: "http://username:password@proxy.example.com:8080"
+```
+
 For multiple client configurations, you can use different prefixes:
 
 ```yaml
@@ -47,7 +71,6 @@ anthropic:
   apiToken: "anthropic-api-key"
   baseUrl: "https://api.anthropic.com"
   APIType: "anthropic"
-
 ```
 
 ## Usage

--- a/openai/README_CN.md
+++ b/openai/README_CN.md
@@ -30,6 +30,30 @@ openai:
   proxyUrl: ""                   # 可选：HTTP 代理 URL
 ```
 
+### 代理配置（proxyUrl）
+
+`proxyUrl` 参数用于在网络受限环境下通过HTTP代理访问OpenAI API。这在以下场景特别有用：
+
+- 当你所在的网络环境无法直接访问OpenAI API
+- 需要通过企业代理或VPN访问外部API
+- 为了提高API访问速度和稳定性
+
+配置示例：
+
+```yaml
+openai:
+  apiToken: "your-api-key"
+  proxyUrl: "http://proxy.example.com:8080"  # HTTP代理服务器地址和端口
+```
+
+你也可以使用带认证的代理：
+
+```yaml
+openai:
+  apiToken: "your-api-key"
+  proxyUrl: "http://username:password@proxy.example.com:8080"
+```
+
 对于多客户端配置，你可以使用不同的前缀：
 
 ```yaml

--- a/openai/go.mod
+++ b/openai/go.mod
@@ -6,8 +6,9 @@ require (
 	github.com/gone-io/gone/v2 v2.0.10
 	github.com/sashabaranov/go-openai v1.38.1
 	github.com/stretchr/testify v1.10.0
+	github.com/gone-io/goner/g v1.0.7
 )
-
+replace github.com/gone-io/goner/g => ../g
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect


### PR DESCRIPTION
- Introduce HTTPDoer interface to support custom HTTP clients
- Add proxyUrl configuration option for OpenAI client
- Update provider to use custom HTTPDoer if provided
- Add test cases for new proxy functionality
- Update README files to include proxy configuration examples