### PR TITLE
fix(viper): error where type is not string with empty default

### DIFF
--- a/viper/config.go
+++ b/viper/config.go
@@ -59,7 +59,10 @@ func (c *configure) Get(key string, v any, defaultVal string) error {
 func (c *configure) get(key string, value any, defaultVale string) error {
 	v := c.conf.Get(key)
 	if v == nil || v == "" {
-		return gone.SetValue(reflect.ValueOf(value), value, defaultVale)
+		if defaultVale != "" {
+			return gone.SetValue(reflect.ValueOf(value), value, defaultVale)
+		}
+		return nil
 	}
 	return gone.ToError(c.conf.UnmarshalKey(key, value))
 }


### PR DESCRIPTION
- Update configure.get method to handle empty default value
- Prevent error from being returned when defaultVale is empty and no value is found- Improve error handling in configuration retrieval