### PR TITLE
fix(otel): prevent multiple registration of OTel providers

### DIFF
--- a/examples/otel/tracer/simple/your_component.go
+++ b/examples/otel/tracer/simple/your_component.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"github.com/gone-io/gone/v2"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -13,7 +12,8 @@ type YourComponent struct {
 }
 
 func (c *YourComponent) HandleRequest(ctx context.Context) {
-	tracer := otel.Tracer("otel-tracer")
+	// tracer := otel.Tracer("otel-tracer")
+	tracer := c.tracer
 
 	// 创建新的 Span
 	ctx, span := tracer.Start(ctx, "handle-request")

--- a/otel/log/helper.go
+++ b/otel/log/helper.go
@@ -64,8 +64,14 @@ func (s *isOtelLogLoadedProvider) Provide(_ string) (g.IsOtelLogLoaded, error) {
 	return true, nil
 }
 
+var h = &helper{}
+
 // Register for openTelemetry LoggerProvider
 func Register(loader gone.Loader) error {
+	if g.IsLoaded(loader, h) {
+		return nil
+	}
+
 	loader.MustLoad(&isOtelLogLoadedProvider{})
 
 	loader.MustLoad(gone.WrapFunctionProvider(func(tagConf string, param struct{}) (otelLog.Logger, error) {
@@ -73,6 +79,6 @@ func Register(loader gone.Loader) error {
 		return global.Logger(name), nil
 	}))
 
-	loader.MustLoad(&helper{})
+	loader.MustLoad(h)
 	return otelHelper.HelpSetPropagator(loader)
 }

--- a/otel/log/helper_test.go
+++ b/otel/log/helper_test.go
@@ -13,6 +13,9 @@ func TestRegister(t *testing.T) {
 	t.Run("use stdout exporter", func(t *testing.T) {
 		gone.
 			NewApp(Register).
+			Loads(func(loader gone.Loader) error {
+				return Register(loader)
+			}).
 			Run(func(is g.IsOtelLogLoaded, log otelLog.Logger) {
 				assert.True(t, bool(is))
 				assert.NotNil(t, log)

--- a/otel/meter/helper.go
+++ b/otel/meter/helper.go
@@ -61,11 +61,17 @@ func (s *providerHelper) Provide(tagConf string) (otelMetric.Meter, error) {
 	return otel.Meter(name), nil
 }
 
+var h = &providerHelper{}
+
 // Register for openTelemetry openTelemetry MeterProvider
 func Register(loader gone.Loader) error {
+	if g.IsLoaded(loader, h) {
+		return nil
+	}
+
 	loader.MustLoad(gone.WrapFunctionProvider(func(_ string, _ struct{}) (g.IsOtelMeterLoaded, error) {
 		return true, nil
 	}))
-	loader.MustLoad(&providerHelper{})
+	loader.MustLoad(h)
 	return otelHelper.HelpSetPropagator(loader)
 }

--- a/otel/meter/helper_test.go
+++ b/otel/meter/helper_test.go
@@ -20,6 +20,9 @@ func TestRegister(t *testing.T) {
 	t.Run("use stdout exporter", func(t *testing.T) {
 		gone.
 			NewApp(Register).
+			Loads(func(loader gone.Loader) error {
+				return Register(loader)
+			}).
 			Run(func(is g.IsOtelMeterLoaded, meter otelMetric.Meter) {
 				assert.True(t, bool(is))
 				assert.NotNil(t, meter)

--- a/otel/tracer/helper.go
+++ b/otel/tracer/helper.go
@@ -55,12 +55,16 @@ func (s *providerHelper) Provide(tagConf string) (otelTrace.Tracer, error) {
 	return otel.Tracer(name), nil
 }
 
+var h = &providerHelper{}
+
 // Register for openTelemetry TracerProvider
 func Register(loader gone.Loader) error {
+	if g.IsLoaded(loader, h) {
+		return nil
+	}
 	loader.MustLoad(gone.WrapFunctionProvider(func(tagConf string, param struct{}) (g.IsOtelTracerLoaded, error) {
 		return true, nil
 	}))
-
-	loader.MustLoad(&providerHelper{})
+	loader.MustLoad(h)
 	return otelHelper.HelpSetPropagator(loader)
 }

--- a/otel/tracer/helper_test.go
+++ b/otel/tracer/helper_test.go
@@ -11,6 +11,9 @@ import (
 func TestRegister(t *testing.T) {
 	gone.
 		NewApp(Register).
+		Loads(func(loader gone.Loader) error {
+			return Register(loader)
+		}).
 		Run(func(is g.IsOtelTracerLoaded, tracer trace.Tracer) {
 			assert.True(t, bool(is))
 			assert.NotNil(t, tracer)


### PR DESCRIPTION
- Add check for existing registration to avoid duplicates
- Use global variable 'h' to ensure single instance of helper
- Implement this change for LoggerProvider, MeterProvider, and TracerProvider